### PR TITLE
Add error message, update dependencies, and bump version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
 
     testCompileOnly(libs.lombok)
     testAnnotationProcessor(libs.lombok)
+    testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.mockbukkit)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 group = "de.nvclas"
-version = "0.6.5"
+version = "0.6.6"
 
 repositories {
     mavenCentral()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 annotations = "26.0.2"
 lombok = "1.18.36"
 runPaper = "2.3.1"
-paperweight-userdev = "2.0.0-beta.14"
+paperweight-userdev = "2.0.0-beta.15"
 paper = "1.21.4-R0.1-SNAPSHOT"
 minecraft = "1.21.4"
 mockbukkit = "4.34.1"
 junit-jupiter = "5.11.4"
-junit-platform-launcher = "1.10.0"
+junit-platform-launcher = "1.11.4"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,18 +2,20 @@
 annotations = "26.0.2"
 lombok = "1.18.36"
 runPaper = "2.3.1"
-paperweightUserdev = "2.0.0-beta.14"
+paperweight-userdev = "2.0.0-beta.14"
 paper = "1.21.4-R0.1-SNAPSHOT"
 minecraft = "1.21.4"
 mockbukkit = "4.34.1"
-junitJupiter = "5.11.4"
+junit-jupiter = "5.11.4"
+junit-platform-launcher = "1.10.0"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 mockbukkit = { group = "org.mockbukkit.mockbukkit", name = "mockbukkit-v1.21", version.ref = "mockbukkit" }
-junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitJupiter" }
+junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit-jupiter" }
+junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-platform-launcher" }
 
 [plugins]
 runPaper = { id = "xyz.jpenilla.run-paper", version.ref = "runPaper" }
-paperweight-userdev = { id = "io.papermc.paperweight.userdev", version.ref = "paperweightUserdev" }
+paperweight-userdev = { id = "io.papermc.paperweight.userdev", version.ref = "paperweight-userdev" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,8 +6,8 @@ paperweight-userdev = "2.0.0-beta.15"
 paper = "1.21.4-R0.1-SNAPSHOT"
 minecraft = "1.21.4"
 mockbukkit = "4.34.1"
-junit-jupiter = "5.11.4"
-junit-platform-launcher = "1.11.4"
+junit-jupiter = "5.12.1"
+junit-platform-launcher = "1.12.1"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/src/main/java/de/nvclas/flats/commands/flats/FlatsCommand.java
+++ b/src/main/java/de/nvclas/flats/commands/flats/FlatsCommand.java
@@ -42,6 +42,7 @@ public class FlatsCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(@NotNull CommandSender sender, @NotNull Command command, @NotNull String label, @NotNull String @NotNull [] args) {
         if (!"flats".equalsIgnoreCase(command.getName()) || !(sender instanceof Player player)) {
+            sender.sendMessage(Flats.PREFIX + I18n.translate("error.only_players"));
             return false;
         }
 

--- a/src/main/resources/i18n/lang_de_DE.properties
+++ b/src/main/resources/i18n/lang_de_DE.properties
@@ -1,4 +1,5 @@
 # Error messages
+error.only_players=§cNur Spieler dürfen das
 error.no_permission=§cBruder, du hast keine Berechtigung dafür
 error.command_delay=§cChill mal. Du musst noch §6%s Sekunden §cwarten
 error.player_not_found=§cAlso irgendwie war dieser Spieler noch nie hier

--- a/src/main/resources/i18n/lang_en_US.properties
+++ b/src/main/resources/i18n/lang_en_US.properties
@@ -1,4 +1,5 @@
 # Error messages
+error.only_players=§cOnly players are allowed to do that
 error.no_permission=§cBro, you don't have permission for that
 error.command_delay=§cChill out. You still have to wait §6%s seconds
 error.player_not_found=§cIt seems this player has never been here

--- a/src/main/resources/i18n/lang_es_ES.properties
+++ b/src/main/resources/i18n/lang_es_ES.properties
@@ -1,4 +1,5 @@
 # Error messages
+error.only_players=§cSolo los jugadores pueden hacer eso
 error.no_permission=§cTío, no tienes permiso para eso
 error.command_delay=§cTranquilo. Tienes que esperar §6%s segundos §cmás
 error.player_not_found=§cParece que este jugador nunca ha estado aquí

--- a/src/main/resources/i18n/lang_fr_FR.properties
+++ b/src/main/resources/i18n/lang_fr_FR.properties
@@ -1,4 +1,5 @@
 # Error messages
+error.only_players=§cSeuls les joueurs peuvent faire ça
 error.no_permission=§cMec, tu n'as pas la permission pour ça
 error.command_delay=§cDu calme. Tu dois attendre encore §6%s secondes
 error.player_not_found=§cOn dirait que ce joueur n'est jamais venu ici


### PR DESCRIPTION
### Summary

This pull request introduces the following updates:
- **New "only players" error message**:
    - Added a localized error message for cases where a non-player entity attempts to execute the `flats` command.
    - Updated command handler logic to use the new message.
- **Dependency updates**:
    - Upgraded `junit-jupiter` to `5.12.1` and `junit-platform-launcher` to `1.12.1` in `libs.versions.toml`.
    - Bumped `paperweight-userdev` to `2.0.0-beta.15`.
    - Made necessary adjustments to version reference keys for consistency, and added `junit-platform-launcher` as a `testRuntimeOnly` dependency.
- **Version bump**:
    - Incremented the project version from `0.6.5` to `0.6.6`.