### PR TITLE
Expand README permissions section with details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,16 @@ The plugin provides several commands to interact with the areas:
 
 The plugin uses a permission system to control access to certain commands:
 
-- `flats.admin` - Permission for administrative commands like creating and deleting flats.
+## Permissions
+
+- `flats.admin` - Administrative permission for commands like plugin updates and system management.
+- `flats.edit` - Allows creating, modifying, and deleting flats.
+- `flats.claim` - Enables claiming and unclaiming existing flats.
+- `flats.show` - Grants access to `/flats show` command to highlight nearby flats visually.
+- `flats.list` - Permission to view a list of all existing flats.
+- `flats.info` - Allows viewing detailed information about individual flats.
+- `flats.trust` - Enables trusting and untrusting other players, allowing them to build on claimed flats.
+- `flats.skip_command_delay` - Bypasses cooldown restrictions on commands that normally have a delay.
 
 ## Developer
 

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -27,7 +27,7 @@ maxFlatSize: 10000
 # Sets the maximum number of claimable flats per player
 maxClaimableFlats: 3
 
-# Set this to true if you prefer to use fine grained permissions using a permission management plugin
+# Set this to true if you prefer to use fine-grained permissions using a permission management plugin
 useAdvancedPermissions: false
 
 # Automatic gamemode change on flat entering or leaving


### PR DESCRIPTION
Expanded the permissions section in the README to include in-depth explanations for each permission. Corrected a minor typo in `settings.yml`. No changes to core functionality were made.